### PR TITLE
[Feature] Create svg helper

### DIFF
--- a/api/Components/BaseComponent.php
+++ b/api/Components/BaseComponent.php
@@ -46,6 +46,15 @@ class BaseComponent
   }
 
   /**
+   * Alias for render
+   * For shorter version in templates
+   */
+  public function r()
+  {
+    return $this->render();
+  }
+
+  /**
    * Registered Components
    * So it can be easily used in templates
    * ```

--- a/api/Components/IconComponent.php
+++ b/api/Components/IconComponent.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Components;
+
+class IconComponent extends BaseComponent
+{
+
+  protected $base_folder = 'templates/svgs/';
+
+  protected $defaultHeight = 32;
+  protected $defaultWidth = 32;
+
+  public function __construct($name, $classes = '')
+  {
+    $this->template = "$name.svg";
+    $this->addData('height', $this->defaultHeight);
+    $this->addData('width', $this->defaultWidth);
+    $this->addData('classes', $classes);
+  }
+
+  public function height($height)
+  {
+    $this->addData('height', $height);
+    return $this;
+  }
+
+  public function width($width)
+  {
+    $this->addData('width', $width);
+    return $this;
+  }
+
+  public function size($size)
+  {
+    return $this->height($size)->width($size);
+  }
+
+}

--- a/api/Components/IconComponent.php
+++ b/api/Components/IconComponent.php
@@ -7,8 +7,8 @@ class IconComponent extends BaseComponent
 
   protected $base_folder = 'templates/svgs/';
 
-  protected $defaultHeight = 32;
-  protected $defaultWidth = 32;
+  protected $defaultHeight = 16;
+  protected $defaultWidth = 16;
 
   public function __construct($name, $classes = '')
   {

--- a/api/helpers/util.php
+++ b/api/helpers/util.php
@@ -43,6 +43,11 @@ function toDate($time)
   return date('M. d, Y', $time);
 }
 
+function icon($name, $classes = '')
+{
+  return new App\Components\IconComponent($name, $classes);
+}
+
 function template($componentKey, ...$args)
 {
 


### PR DESCRIPTION
<h1>Easily Create a resuable svg icons</h1>

<h4>Usage</h4>

1. Add your svg on templates/svgs directory
2. make sure the extension name is .svg.php (e.g. edit.svg.php)
3. Now you can use your icon anywhere on tamplates using the icon helper function

<h4>Example</h1>

- icon('edit')->render() //Basic
- icon('edit', 'inline')->render() //Optional Second argument for classes
- icon('edit')->size(20) //Size method for custom sizes; Default = 16

